### PR TITLE
Add additional hooks, and stop updating modules by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ task :custom_test, [:env] do |_, args|
 end
 ```
 
+### Task and Hooks
+
+TerraformDevKit provides a set of generic tasks to perform:
+
+* `prepare`: prepares the environment
+* `plan`: shows the plan to create the infrastructure
+* `apply`: creates the infrastructure
+* `destroy`: destroys the infrastructure
+* `clean`: cleans the environment (after destroying the infrastructure)
+* `test`: tests a local environment
+* `preflight`: creates a temporary infrastructure and runs the test task
+
+Additionally, TerraformDevKit allows users to define a set of hooks that will be called during the different steps required to complete the previous list of tasks. The following hooks are available:
+
+* `pre_apply`: invoked before `apply` task runs
+* `post_apply`: invoked after `apply` task runs
+* `pre_destroy`: invoked before `destroy` task runs
+* `post_destroy`: invoked after `destroy` task runs
+* `custom_prepare`: invoked during the preparation process, before terraform is initialized
+* `custom_test`: invoked during as part of the `test` task, right after `apply` completes.
+
 ### Sample Terraform/Terragrunt Templates
 
 The following file (`main.tf.mustache`) contains the infrastructure configuration (a single S3 bucket) as well as information related to the AWS provider.
@@ -148,9 +169,7 @@ terragrunt = {
 
 ### Injecting Additional Variables into Template Files
 
-In addition to the default variables that are passed to Mustache when rendering
-a template file, users can provide additional variables. To do so, users must register a procedure that receives the environment as a parameter and returns
-a map with the extra variables and their values. An example is shown next:
+In addition to the default variables that are passed to Mustache when rendering a template file, users can provide additional variables. To do so, users must register a procedure that receives the environment as a parameter and returns a map with the extra variables and their values. An example is shown next:
 
 ```ruby
 TDK::TerraformConfigManager.register_extra_vars_proc(
@@ -160,14 +179,11 @@ TDK::TerraformConfigManager.register_extra_vars_proc(
 )
 ```
 
-### Skipping Module Updates
+### Updating Modules
 
-For safety and correctness reasons, TerraformDevKit requests to update every
-module when it executes Terraform. This may take a while, depending on the
-number of modules used in the infrastructure.
+Terraform will get the necessary modules every time a new environment is created. Once the modules are cached, there is generally no need to keep updating the modules each time Terraform is executed. When using a module repository it is possible to select a specific version to use (as shown [here](https://www.terraform.io/docs/modules/sources.html#ref)). In such a case, Terraform will automatically update the modules whenever the version number is changed.
 
-When users are sure that an update is not necessary, this step can be skipped
-by setting the environment variable `TF_DEVKIT_SKIP_MODULE_UPDATE` to `true`.
+When using local modules (e.g., during development process) it might be desirable to update the modules every time Terraform runs. This can be achieved by setting the environment variable `TF_DEVKIT_UPDATE_MODULES` to `true`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ task :custom_test, [:env] do |_, args|
 end
 ```
 
-### Task and Hooks
+### Tasks and Hooks
 
 TerraformDevKit provides a set of generic tasks to perform:
 

--- a/lib/TerraformDevKit/terraform_config_manager.rb
+++ b/lib/TerraformDevKit/terraform_config_manager.rb
@@ -17,10 +17,8 @@ module TerraformDevKit
     end
 
     def self.update_modules?
-      skip_update = ENV.fetch('TF_DEVKIT_SKIP_MODULE_UPDATE', 'false')
-                       .strip
-                       .downcase
-      skip_update != 'true'
+      var = ENV.fetch('TF_DEVKIT_UPDATE_MODULES', 'false')
+      var.strip.casecmp('true').zero?
     end
 
     private_class_method

--- a/lib/TerraformDevKit/terraform_installer.rb
+++ b/lib/TerraformDevKit/terraform_installer.rb
@@ -10,11 +10,19 @@ module TerraformDevKit
     LOCAL_FILE_NAME = 'terraform.zip'.freeze
 
     def self.installed_terraform_version
-      version = Command.run('terraform --version')[0]
-      match = /Terraform v(\d+\.\d+\.\d+)/.match(version)
-      match[1] unless match.nil?
+      extract_version(Command.run('terraform --version'))
     rescue
       nil
+    end
+
+    def self.extract_version(output)
+      # Terraform vx.y.z might be anywhere in the output (warnings may appear
+      # before the version does). Therefore we scan all the lines.
+
+      matches = output.map { |line| /Terraform v(\d+\.\d+\.\d+)/.match(line) }
+                      .reject(&:nil?)
+
+      matches.count == 1 ? matches[0][1] : nil
     end
 
     def self.install_local(version, directory: Dir.pwd)

--- a/lib/TerraformDevKit/version.rb
+++ b/lib/TerraformDevKit/version.rb
@@ -1,3 +1,3 @@
 module TerraformDevKit
-  VERSION = '0.1.13'.freeze
+  VERSION = '0.1.14'.freeze
 end

--- a/spec/terraform_config_manager_spec.rb
+++ b/spec/terraform_config_manager_spec.rb
@@ -85,4 +85,38 @@ RSpec.describe TDK::TerraformConfigManager do
       expect(File.read('envs/dev/test.tfvars')).to eq(tfvars_output)
     end
   end
+
+  describe '#update_modules?' do
+    before(:example) do
+      @saved_env_var = ENV['TF_DEVKIT_UPDATE_MODULES']
+    end
+
+    after(:example) do
+      if @saved_env_var.nil?
+        ENV.delete('TF_DEVKIT_UPDATE_MODULES')
+      else
+        ENV['TF_DEVKIT_UPDATE_MODULES'] = @saved_env_var
+      end
+    end
+
+    context 'env var is not set' do
+      it 'returns false' do
+        expect(TDK::TerraformConfigManager.update_modules?).to be false
+      end
+    end
+
+    context 'env var is set' do
+      [
+        { value: 'true',  expected: true },
+        { value: 'false', expected: false },
+        { value: 'foo',   expected: false }
+      ].each do |example|
+        it 'updates modules only if env var is true' do
+          ENV['TF_DEVKIT_UPDATE_MODULES'] = example[:value]
+          expect(TDK::TerraformConfigManager.update_modules?)
+            .to eq(example[:expected])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds the following hooks `pre_apply` and `pre_destroy`.
`custom_destroy` gets renamed to `post_destroy`.

Additionally, it fixes #15 