### PR TITLE
use fixed version of rubyzip

### DIFF
--- a/TerraformDevKit.gemspec
+++ b/TerraformDevKit.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1'
   spec.add_runtime_dependency 'mustache', '~> 1.0'
   spec.add_runtime_dependency 'rainbow', '~> 3.0'
-  spec.add_runtime_dependency 'rubyzip', '~> 1.2'
+  spec.add_runtime_dependency 'rubyzip', '1.2.1'
 end


### PR DESCRIPTION
Version 1.2.2 of [rubyzip](https://github.com/rubyzip/rubyzip/releases/tag/v1.2.2) was released a week ago that includes a breaking change for TDK. When we extract `terraform.exe` the file is marked as unsafe and is not extracted ([see line 165](https://github.com/rubyzip/rubyzip/commit/d07b13a6cf0a413e010c48879aebd9576bfb5f68) of `entry.rb`) so all deployments fail in the prepare stage. 

This change locks in the version of rubyzip to the one we were previously depending on until we investigate a proper solution. 