### PR TITLE
Specify file path when extracting

### DIFF
--- a/lib/TerraformDevKit/terraform_installer.rb
+++ b/lib/TerraformDevKit/terraform_installer.rb
@@ -53,7 +53,7 @@ module TerraformDevKit
         zip_file.each do |entry|
           puts "Extracting #{entry.name}"
           entry.restore_permissions = true
-          entry.extract { true }
+          entry.extract(entry.name) { true }
         end
       end
     end

--- a/lib/TerraformDevKit/version.rb
+++ b/lib/TerraformDevKit/version.rb
@@ -1,3 +1,3 @@
 module TerraformDevKit
-  VERSION = '0.3.7'.freeze
+  VERSION = '0.3.8'.freeze
 end


### PR DESCRIPTION
Version 1.2.2 of [rubyzip](https://github.com/rubyzip/rubyzip/releases/tag/v1.2.2) was released a week ago that includes a breaking change for TDK. When we extract `terraform.exe` the file is marked as unsafe and is not extracted ([see line 165](https://github.com/rubyzip/rubyzip/commit/d07b13a6cf0a413e010c48879aebd9576bfb5f68) of `entry.rb`) so all deployments fail in the prepare stage. 

This change mimics what rubyzip was doing in version 1.2.1 by passing the extracted files file name to the extract method.